### PR TITLE
Get the current transaction, active or not

### DIFF
--- a/newrelic/hooks/application_celery.py
+++ b/newrelic/hooks/application_celery.py
@@ -19,7 +19,7 @@ from newrelic.api.transaction import current_transaction
 def CeleryTaskWrapper(wrapped, application=None, name=None):
 
     def wrapper(wrapped, instance, args, kwargs):
-        transaction = current_transaction()
+        transaction = current_transaction(active_only=False)
 
         if callable(name):
             # Start Hotfix v2.2.1.


### PR DESCRIPTION
Potential fix for the issue of launching a celery chord inside a task with a stopped new relic transaction
